### PR TITLE
Avoid percentage-based flex-basis

### DIFF
--- a/src/apis/StyleSheet/createReactDOMStyle.js
+++ b/src/apis/StyleSheet/createReactDOMStyle.js
@@ -169,7 +169,7 @@ const createReducer = (style, styleProps) => {
         if (value > 0) {
           resolvedStyle.flexGrow = value;
           resolvedStyle.flexShrink = 1;
-          resolvedStyle.flexBasis = '0%';
+          resolvedStyle.flexBasis = 'auto';
         } else if (value === 0) {
           resolvedStyle.flexGrow = 0;
           resolvedStyle.flexShrink = 0;


### PR DESCRIPTION
Addresses #574.

Percentages are completely valid, but cause an issue in older versions of WebKit (safari), as documented in this bug here: https://github.com/philipwalton/flexbugs/issues/192

**Before submitting a pull request,** please make sure you have followed the steps the CONTRIBUTING guide.
